### PR TITLE
More Cognitect-ish

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
  * Added `-V` / `--verbose` for turning the ClojureScript compiler verbose flag on when you want it.
  * Made all options repeatable, so now you can specify `-d test -d other-test-dir` as well as `-v some-test -v some-other-test`.
  * Output the rendered ClojureScript test runner to the output directory, so you only have to git ignore `cljs-test-runner-out`.
+ * Added `--compile-opts` thanks to [@kthu](https://github.com/kthu) in [#7](https://github.com/Olical/cljs-test-runner/pull/7).
 
 ## 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
  * `-e` became `-x` as a shortcut for `--env`.
  * Added `--namespace` (`-n`) so you can test a single namespace by it's symbol.
  * Added `--namespace-regex` (`-r`) so you can test namespaces matching a regex. This default to any namespace ending in `-test`.
+ * Added filtering of tests by symbol or metadata keywords.
+ * Made all options repeatable, so now you can specify `-d test -d other-test-dir` as well as `-v some-test -v some-other-test`.
+ * Output the rendered ClojureScript test runner to the output directory, so you only have to git ignore `cljs-test-runner-out`.
 
 ## 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,11 @@
 ## 2.0.0
 
  * `-e` became `-x` as a shortcut for `--env`.
+ * `-h` became `-H`, like the Cognitect test-runner.
  * Added `--namespace` (`-n`) so you can test a single namespace by it's symbol.
  * Added `--namespace-regex` (`-r`) so you can test namespaces matching a regex. This default to any namespace ending in `-test`.
  * Added filtering of tests by symbol or metadata keywords.
+ * Added `-V` / `--verbose` for turning the ClojureScript compiler verbose flag on when you want it.
  * Made all options repeatable, so now you can specify `-d test -d other-test-dir` as well as `-v some-test -v some-other-test`.
  * Output the rendered ClojureScript test runner to the output directory, so you only have to git ignore `cljs-test-runner-out`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # cljs-test-runner changes
 
+## 2.0.0
+
+ * `-e` became `-x` as a shortcut for `--env`.
+ * Added `--namespace` (`-n`) so you can test a single namespace by it's symbol.
+ * Added `--namespace-regex` (`-r`) so you can test namespaces matching a regex. This default to any namespace ending in `-test`.
+
 ## 1.0.0
 
  * `--watch` support thanks to [@eval](https://github.com/eval) in [#2](https://github.com/Olical/cljs-test-runner/pull/2).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Under the hood it's building a test runner file, compiling everything and then e
 In simple cases, you'll be able to execute your tests with something as succinct as the following line.
 
 ```bash
-$ clojure -Sdeps '{:deps {olical/cljs-test-runner {:mvn/version "1.0.0"}}}' -m cljs-test-runner.main
+$ clojure -Sdeps '{:deps {olical/cljs-test-runner {:mvn/version "2.0.0"}}}' -m cljs-test-runner.main
 ```
 
 It's likely that your tests will require dependencies and configuration that would become unwieldy in this format. You will need to add the dependency and `--main` (`-m`) parameter to your `deps.edn` file.
@@ -21,7 +21,7 @@ I recommend you put this under an alias such as `test` or `cljs-test` if that's 
 ```clojure
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/clojurescript {:mvn/version "1.10.145"}}
- :aliases {:test {:extra-deps {olical/cljs-test-runner {:mvn/version "1.0.0"}}
+ :aliases {:test {:extra-deps {olical/cljs-test-runner {:mvn/version "2.0.0"}}
                   :main-opts ["-m" "cljs-test-runner.main"]}}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ You can use `--help` to see the current flags and their default values.
 
 ```bash
 $ clojure -Atest --help
-  -d, --dir DIRNAME            test                  The directory containing your test files
+  -d, --dir DIRNAME            #{"test"}             The directory containing your test files
   -n, --namespace SYMBOL                             Symbol indicating a specific namespace to test.
-  -r, --namespace-regex REGEX  .*-test$              Regex for namespaces to test. Only namespaces ending in '-test' are evaluated by default.
+  -r, --namespace-regex REGEX  .*\-test$             Regex for namespaces to test. Only namespaces ending in '-test' are evaluated by default.
+  -v, --var SYMBOL                                   Symbol indicating the fully qualified name of a specific test.
+  -i, --include SYMBOL                               Run only tests that have this metadata keyword.
+  -e, --exclude SYMBOL                               Exclude tests with this metadata keyword.
   -o, --out DIRNAME            cljs-test-runner-out  The output directory for compiled test code
   -x, --env ENV                node                  Run your tests in either node or phantom.
   -w, --watch DIRNAME                                Directory to watch for changes (alongside the test directory). May be repeated.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ I recommend you put this under an alias such as `test` or `cljs-test` if that's 
 ```clojure
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/clojurescript {:mvn/version "1.10.145"}}
- :aliases {:test {:extra-deps {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+ :aliases {:test {:extra-deps {olical/cljs-test-runner {:mvn/version "1.0.0"}}
                   :main-opts ["-m" "cljs-test-runner.main"]}}}
 ```
 
@@ -40,20 +40,22 @@ Ran 2 tests containing 2 assertions.
 
 ## Configuration
 
-You can configure the test runner with a few different flags, the most important one is `--env` (`-e`) which allows you to swap from node to [phantom][] if required. I would recommend sticking to node and using something like [jsdom][], but this does come down to preference and technical requirements.
+You can configure the test runner with a few different flags, the most important one is `--env` (`-x`) which allows you to swap from node to [phantom][] if required. I would recommend sticking to node and using something like [jsdom][], but this does come down to preference and technical requirements.
 
 ```bash
-$ clojure -Atest -e phantom
+$ clojure -Atest -x phantom
 ```
 
 You can use `--help` to see the current flags and their default values.
 
 ```bash
 $ clojure -Atest --help
-  -e, --env ENV     node                    Run your tests in either node or phantom
-  -s, --src PATH    ./test                  The directory containing your test files
-  -o, --out PATH    ./cljs-test-runner-out  The output directory for compiled test code
-  -w, --watch PATH                          Directory to watch for changes (alongside the src-path). May be repeated.
+  -x, --env ENV                node                  Run your tests in either node or phantom.
+  -n, --namespace SYMBOL                             Symbol indicating a specific namespace to test.
+  -r, --namespace-regex REGEX  .*-test$              Regex for namespaces to test. Only namespaces ending in '-test' are evaluated by default.
+  -d, --dir DIRNAME            test                  The directory containing your test files
+  -o, --out DIRNAME            cljs-test-runner-out  The output directory for compiled test code
+  -w, --watch DIRNAME                                Directory to watch for changes (alongside the test dir-path). May be repeated.
   -h, --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ In simple cases, you'll be able to execute your tests with something as succinct
 $ clojure -Sdeps '{:deps {olical/cljs-test-runner {:mvn/version "2.0.0"}}}' -m cljs-test-runner.main
 ```
 
+> Note: The generated test code is placed in the directory `cljs-test-runner-out` by default (configure with `--out`), you should add that to your `.gitignore` file.
+
 It's likely that your tests will require dependencies and configuration that would become unwieldy in this format. You will need to add the dependency and `--main` (`-m`) parameter to your `deps.edn` file.
 
 I recommend you put this under an alias such as `test` or `cljs-test` if that's already taken by your Clojure tests.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can use `--help` to see the current flags and their default values.
 
 ```bash
 $ clojure -Atest --help
-  -d, --dir DIRNAME            #{"test"}             The directory containing your test files
+  -d, --dir DIRNAME            test                  The directory containing your test files
   -n, --namespace SYMBOL                             Symbol indicating a specific namespace to test.
   -r, --namespace-regex REGEX  .*\-test$             Regex for namespaces to test. Only namespaces ending in '-test' are evaluated by default.
   -v, --var SYMBOL                                   Symbol indicating the fully qualified name of a specific test.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can configure the test runner with a few different flags, the most important
 $ clojure -Atest -x phantom
 ```
 
-If you need to use `foreign-libs` or any cljs compiler flags that are not mirrored in cljs-test-runner's flags, you can put them into an edn file and point to that file using the `--compile-opts` flag. Note that any flags that are given explicitly using cljs-test-runner flags (or have default values) will override any options given in the edn file.
+If you need to use `foreign-libs` or any cljs compiler flags that are not mirrored in cljs-test-runner's flags, you can put them into an EDN file and point to that file using the `--compile-opts` flag.
 
 You can use `--help` to see the current flags and their default values.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ $ clojure -Atest --help
   -o, --out DIRNAME            cljs-test-runner-out  The output directory for compiled test code
   -x, --env ENV                node                  Run your tests in either node or phantom.
   -w, --watch DIRNAME                                Directory to watch for changes (alongside the test directory). May be repeated.
-  -h, --help
+  -V, --verbose                                      Flag passed directly to the ClojureScript compiler to enable verbose compiler output.
+  -H, --help
 ```
 
 ## Gotchas

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ You can use `--help` to see the current flags and their default values.
 
 ```bash
 $ clojure -Atest --help
-  -x, --env ENV                node                  Run your tests in either node or phantom.
+  -d, --dir DIRNAME            test                  The directory containing your test files
   -n, --namespace SYMBOL                             Symbol indicating a specific namespace to test.
   -r, --namespace-regex REGEX  .*-test$              Regex for namespaces to test. Only namespaces ending in '-test' are evaluated by default.
-  -d, --dir DIRNAME            test                  The directory containing your test files
   -o, --out DIRNAME            cljs-test-runner-out  The output directory for compiled test code
-  -w, --watch DIRNAME                                Directory to watch for changes (alongside the test dir-path). May be repeated.
+  -x, --env ENV                node                  Run your tests in either node or phantom.
+  -w, --watch DIRNAME                                Directory to watch for changes (alongside the test directory). May be repeated.
   -h, --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ $ clojure -Atest --help
   -h, --help
 ```
 
+## Gotchas
+
+ * Make sure the directory (or directories!) containing your tests are on your Java class path. Specify this with a top level `:paths` key in your `deps.edn` file.
+
 ## Unlicenced
 
 Find the full [unlicense][] in the `UNLICENSE` file, but here's a snippet.

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
-        org.clojure/clojurescript {:mvn/version "1.10.238"}
+        org.clojure/clojurescript {:mvn/version "1.10.312"}
         org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}
         org.clojure/tools.cli {:mvn/version "0.3.7"}
         doo {:mvn/version "0.1.10"}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:deps {org.clojure/clojure {:mvn/version "1.9.0"}
+{:paths ["src" "test" "other-tests"]
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/clojurescript {:mvn/version "1.10.312"}
         org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}
         org.clojure/tools.cli {:mvn/version "0.3.7"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/clojurescript {:mvn/version "1.10.238"}
         org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}
-        org.clojure/tools.cli {:mvn/version "0.3.5"}
+        org.clojure/tools.cli {:mvn/version "0.3.7"}
         doo {:mvn/version "0.1.10"}}
  :aliases {:test {:main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/other-tests/other/other_test.cljs
+++ b/other-tests/other/other_test.cljs
@@ -1,0 +1,6 @@
+(ns other.other-test
+  (:require [cljs.test :as t]))
+
+(t/deftest other-should-run
+  (t/testing "this should run in the other dir"
+    (t/is (= 1 1))))

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>olical</groupId>
   <artifactId>cljs-test-runner</artifactId>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <name>cljs-test-runner</name>
   <description>Run all of your ClojureScript tests with one simple command.</description>
   <url>https://github.com/Olical/cljs-test-runner</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojurescript</artifactId>
-      <version>1.10.238</version>
+      <version>1.10.312</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.cli</artifactId>
-      <version>0.3.5</version>
+      <version>0.3.7</version>
     </dependency>
     <dependency>
       <groupId>doo</groupId>

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -11,7 +11,7 @@
   [nses]
   (let [nses-str (str/join " " nses)
         quoted-nses-str (str/join " " (map #(str "'" %) nses))]
-    (str "(ns test.runner (:require [doo.runner :refer-macros [doo-tests]] " nses-str ") ) (doo-tests " quoted-nses-str ")")))
+    (str "(ns test.runner (:require [doo.runner :refer-macros [doo-tests]] " nses-str ")) (doo-tests " quoted-nses-str ")")))
 
 (defn ns-filter-fn
   "Given a possible namespace symbol and regex, return a function that returns true if it's given namespace matches one of the rules."
@@ -78,10 +78,8 @@
         (exit @exit-code)))))
 
 (def cli-options
-  [["-x" "--env ENV" "Run your tests in either node or phantom."
-    :default :node
-    :default-desc "node"
-    :parse-fn keyword]
+  [["-d" "--dir DIRNAME" "The directory containing your test files"
+    :default "test"]
    ["-n" "--namespace SYMBOL" "Symbol indicating a specific namespace to test."
     :id :ns-symbol
     :parse-fn symbol]
@@ -90,10 +88,12 @@
     :default-desc ".*-test$"
     :default #".*-test$"
     :parse-fn re-pattern]
-   ["-d" "--dir DIRNAME" "The directory containing your test files"
-    :default "test"]
    ["-o" "--out DIRNAME" "The output directory for compiled test code"
     :default "cljs-test-runner-out"]
+   ["-x" "--env ENV" "Run your tests in either node or phantom."
+    :default :node
+    :default-desc "node"
+    :parse-fn keyword]
    ["-w" "--watch DIRNAME" "Directory to watch for changes (alongside the test directory). May be repeated."
     :assoc-fn (fn [m k v] (update m k (fnil conj [:dir]) v))]
    ["-h" "--help"]])

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -188,20 +188,24 @@
       :else (test-cljs-namespaces-in-dir options))))
 
 (comment
+  (defmacro run [& args]
+    `(with-redefs [exit println]
+       (-main ~@args)))
+
   ;; all
-  (with-redefs [exit println] (-main))
+  (run)
 
   ;; ns symbol
-  (with-redefs [exit println] (-main "-n" "example.yes-test"))
+  (run "-n" "example.yes-test")
 
   ;; ns regexs
-  (with-redefs [exit println] (-main "-r" ".*yes.*"))
+  (run "-r" ".*yes.*")
 
   ;; var symbol
-  (with-redefs [exit println] (-main "-v" "example.yes-test/should-run"))
+  (run "-v" "example.yes-test/should-run")
 
   ;; include
-  (with-redefs [exit println] (-main "-i" "integration"))
+  (run "-i" "integration")
 
   ;; exclude
-  (with-redefs [exit println] (-main "-e" "integration")))
+  (run "-e" "integration"))

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -35,11 +35,14 @@
 (defn render-test-runner-cljs
   "Renders a ClojureScript test runner from a seq of namespaces."
   [nses {:keys [var]}]
-  (let [nses-str (str/join " " nses)
-        quoted-nses-str (str/join " " (map #(str "'" %) nses))
-        double-quoted-nses-str (str/join " " (map #(str "(quote '" % ")") nses))
-        filter-nses-str (str "(filter-vars! [" double-quoted-nses-str "] (var-filter {:var (quote '" var "), :include nil, :exclude nil}))")]
-    (str "(ns test.runner (:require [doo.runner :refer-macros [doo-tests]] " nses-str ")) " ns-filter-cljs " " filter-nses-str " (doo-tests " quoted-nses-str ")")))
+  (doto (str
+    "(ns test.runner
+       (:require [doo.runner :refer-macros [doo-tests]]"
+                 (str/join " " nses)"))"
+     ns-filter-cljs
+     "(filter-vars! [" (str/join " " (map #(str "'" %) nses)) "]
+        (var-filter {:var '" var ", :include nil, :exclude nil}))"
+     "(doo-tests " (str/join " " (map #(str "'" %) nses)) ")") prn))
 
 (defn ns-filter-fn
   "Given a possible namespace symbol and regex, return a function that returns true if it's given namespace matches one of the rules."

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -88,7 +88,7 @@
    ["-h" "--help"]])
 
 (defn -main
-  "Creates a ClojureScript test runner and executes it with node."
+  "Creates a ClojureScript test runner and executes it with node (by default)."
   [& args]
   (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)
         options (update options :watch (partial replace options))]
@@ -96,4 +96,3 @@
       (:help options) (exit 0 summary)
       errors (exit 1 (error-msg errors))
       :else (test-cljs-namespaces-in-dir options))))
-

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -104,13 +104,15 @@
                                                        :include include
                                                        :exclude exclude}))
         exit-code (atom 1)
-        src-path (str/join "/" [out "generated-test-runner.cljs"])
+        gen-path (str/join "/" [out "gen"])
+        src-path (str/join "/" [gen-path "test-runner.cljs"])
         out-path (str/join "/" [out "test-runner.js"])
         {:keys [target doo-env]} (case env
                                    :node {:target :nodejs
                                           :doo-env :node}
                                    :phantom {:target :browser
                                              :doo-env :phantom})]
+    (io/make-parents src-path)
     (spit src-path test-runner-cljs)
     (try
       (let [doo-opts {}
@@ -123,7 +125,7 @@
             watch-opts (assoc build-opts :watch-fn run-tests-fn)]
         (if (seq watch)
           (cljs/watch (apply cljs/inputs watch) watch-opts)
-          (do (cljs/build out build-opts)
+          (do (cljs/build gen-path build-opts)
               (->> (run-tests-fn) :exit (reset! exit-code)))))
       (catch Exception e
         (println e))
@@ -205,4 +207,7 @@
   (run "-i" "integration")
 
   ;; exclude
-  (run "-e" "integration"))
+  (run "-e" "integration")
+
+  ;; more dirs
+  (run "-d" "other-tests"))

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -50,15 +50,15 @@
                              (->> (filter (ns-filter-fn ns-symbol ns-regex)))
                              (render-test-runner-cljs))
         exit-code (atom 1)
-        dir-path (str/join "/" [dir "runner.cljs"])
+        src-path (str/join "/" [dir "cljs-test-runner.temp.cljs"])
         out-path (str/join "/" [out "test-runner.js"])
         {:keys [target doo-env]} (case env
                                    :node {:target :nodejs
                                           :doo-env :node}
                                    :phantom {:target :browser
                                              :doo-env :phantom})]
-    (spit dir-path test-runner-cljs)
-    (shutdown-hook #(io/delete-file dir-path))
+    (spit src-path test-runner-cljs)
+    (shutdown-hook #(io/delete-file src-path))
     (try
       (let [doo-opts {}
             build-opts {:output-to out-path
@@ -94,7 +94,7 @@
     :default "test"]
    ["-o" "--out DIRNAME" "The output directory for compiled test code"
     :default "cljs-test-runner-out"]
-   ["-w" "--watch DIRNAME" "Directory to watch for changes (alongside the test dir-path). May be repeated."
+   ["-w" "--watch DIRNAME" "Directory to watch for changes (alongside the test directory). May be repeated."
     :assoc-fn (fn [m k v] (update m k (fnil conj [:dir]) v))]
    ["-h" "--help"]])
 

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -189,9 +189,11 @@
       :else (test-cljs-namespaces-in-dir options))))
 
 (comment
-  (defmacro run [& args]
-    `(with-redefs [exit println]
-       (-main ~@args)))
+  (defn run
+    "Runs the test suite with the give arguments without letting the process die at the end."
+    [& args]
+    (with-redefs [exit println]
+      (apply -main args)))
 
   ;; all
   (run)

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -147,6 +147,7 @@
 (def cli-options
   [["-d" "--dir DIRNAME" "The directory containing your test files"
     :default #{"test"}
+    :default-desc "test"
     :assoc-fn accumulate]
    ["-n" "--namespace SYMBOL" "Symbol indicating a specific namespace to test."
     :id :ns-symbols

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -126,9 +126,7 @@
             watch-opts (assoc build-opts :watch-fn run-tests-fn)]
 
         (if (seq watch)
-          (let [watch-paths (into watch (cons gen-path dir))]
-            (println "Watching paths:" watch-paths)
-            (cljs/watch (apply cljs/inputs watch-paths) watch-opts))
+          (cljs/watch (apply cljs/inputs (into watch (cons gen-path dir))) watch-opts)
           (do (cljs/build gen-path build-opts)
               (->> (run-tests-fn) :exit (reset! exit-code)))))
       (catch Exception e

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -176,7 +176,7 @@
    ["-x" "--env ENV" "Run your tests in either node or phantom."
     :default :node
     :default-desc "node"
-    :parse-fn keyword]
+    :parse-fn parse-kw]
    ["-w" "--watch DIRNAME" "Directory to watch for changes (alongside the test directory). May be repeated."
     :assoc-fn accumulate]
    ["-c" "--compile-opts PATH" "EDN file containing opts to be passed to the ClojureScript compiler."]

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -1,4 +1,5 @@
 (ns cljs-test-runner.main
+  "Discover and run ClojureScript tests in node (by default)."
   (:require [clojure.tools.namespace.find :as find]
             [clojure.java.io :as io]
             [clojure.string :as str]
@@ -88,7 +89,9 @@
   (str "The following errors occurred while parsing your command:\n\n"
        (str/join \newline errors)))
 
-(defn find-namespaces-in-dirs [dirs]
+(defn find-namespaces-in-dirs
+  "Given a set of directory paths, find every ClojureScript namespace within those directories and return it as one sequence."
+  [dirs]
   (mapcat #(find/find-namespaces-in-dir (io/file %) find/cljs) dirs))
 
 (defn test-cljs-namespaces-in-dir
@@ -138,6 +141,7 @@
   (update-in m [k] (fnil conj #{}) v))
 
 (def cli-options
+  "Options for use with clojure.tools.cli."
   [["-d" "--dir DIRNAME" "The directory containing your test files"
     :default #{"test"}
     :default-desc "test"

--- a/test/example/yes_test.cljs
+++ b/test/example/yes_test.cljs
@@ -4,3 +4,7 @@
 (t/deftest should-run
   (t/testing "this should run"
     (t/is (= 1 1))))
+
+(t/deftest ^:integration maybe-run
+  (t/testing "this may run"
+    (t/is (= 2 2))))


### PR DESCRIPTION
 * [x] Updating the CLI format to reflect the Cognitect test-runner, this is a (very small) breaking change. :sob:
 * [x] Adding namespace symbol and regex filtering, just like Cognitect's version.
 * [x] Adding test filtering by symbol or meta keywords.
 * [x] Make all CLI options take multiple values, not just one.

Started looking into this because of #4. Yet to work out if I can do the actual test filtering that the original issue mentions yet, at least this adds namespace filtering :smile:

Sorry about the CLI change, but I would like to be able to run this CLJS port or the original with the same flags if possible. Things like `-e` for `--env` were going to conflict with `--exclude` if I added them anyway.