### PR TITLE
Add option to pass edn file with cljs compiler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,17 @@ You can configure the test runner with a few different flags, the most important
 $ clojure -Atest -e phantom
 ```
 
-If you need to use any cljs compiler options that are not mirrored in cljs-test-runners flags, you can put them into an edn file and point to that file using the `--config-file` flag. This will work like `cljs-main`'s `-co` flag. Note that options that are given explicitly using cljs-test-runner flags (or have default values), will overwrite any options given in the file.  You can use `--help` to see the current flags and their default values.
+If you need to use `foreign-libs` or any cljs compiler flags that are not mirrored in cljs-test-runner's flags, you can put them into an edn file and point to that file using the `--compile-opts` flag. Note that any flags that are given explicitly using cljs-test-runner flags (or have default values) will override any options given in the edn file.
+
+You can use `--help` to see the current flags and their default values.
 
 ```bash
 $ clojure -Atest --help
-  -e, --env ENV     node                    Run your tests in either node or phantom
-  -s, --src PATH    ./test                  The directory containing your test files
-  -o, --out PATH    ./cljs-test-runner-out  The output directory for compiled test code
-  -w, --watch PATH                          Directory to watch for changes (alongside the src-path). May be repeated.
-  -c, --config-file PATH                    Edn file containing opts to be passed to the cljs compiler.
+  -e, --env ENV       node                    Run your tests in either node or phantom
+  -s, --src PATH      ./test                  The directory containing your test files
+  -o, --out PATH      ./cljs-test-runner-out  The output directory for compiled test code
+  -w, --watch PATH                            Directory to watch for changes (alongside the src-path). May be repeated.
+  -c, --complile-opts PATH                    Edn file containing opts to be passed to the cljs compiler.
   -h, --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can configure the test runner with a few different flags, the most important
 $ clojure -Atest -e phantom
 ```
 
-You can use `--help` to see the current flags and their default values.
+If you need to use any cljs compiler options that are not mirrored in cljs-test-runners flags, you can put them into an edn file and point to that file using the `--config-file` flag. This will work like `cljs-main`'s `-co` flag. Note that options that are given explicitly using cljs-test-runner flags (or have default values), will overwrite any options given in the file.  You can use `--help` to see the current flags and their default values.
 
 ```bash
 $ clojure -Atest --help
@@ -54,6 +54,7 @@ $ clojure -Atest --help
   -s, --src PATH    ./test                  The directory containing your test files
   -o, --out PATH    ./cljs-test-runner-out  The output directory for compiled test code
   -w, --watch PATH                          Directory to watch for changes (alongside the src-path). May be repeated.
+  -c, --config-file PATH                    Edn file containing opts to be passed to the cljs compiler.
   -h, --help
 ```
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:deps {org.clojure/clojure {:mvn/version "1.9.0"}
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/clojurescript {:mvn/version "1.10.238"}
         org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}
         org.clojure/tools.cli {:mvn/version "0.3.5"}

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -41,7 +41,7 @@
 
 (defn test-cljs-namespaces-in-dir
   "Execute all ClojureScript tests in a directory."
-  [{:keys [env src out watch compiler-config]}]
+  [{:keys [env src out watch compile-opts]}]
   (let [test-runner-cljs (-> (io/file src)
                              (find/find-namespaces-in-dir find/cljs)
                              (->> (filter test-namespace?))
@@ -59,7 +59,7 @@
     (shutdown-hook #(io/delete-file src-path))
     (try
       (let [doo-opts {}
-            build-opts (merge (-> compiler-config
+            build-opts (merge (-> compile-opts
                                   (#(when % (slurp %)))
                                   clojure.edn/read-string)
                               {:output-to out-path
@@ -89,7 +89,7 @@
     :default "./cljs-test-runner-out"]
    ["-w" "--watch PATH" "Directory to watch for changes (alongside the src-path). May be repeated."
     :assoc-fn (fn [m k v] (update m k (fnil conj [:src]) v))]
-   ["-c" "--compiler-config PATH" "Edn file containing opts to be passed to the cljs compiler."]
+   ["-c" "--compile-opts PATH" "Edn file containing opts to be passed to the cljs compiler."]
    ["-h" "--help"]])
 
 (defn -main


### PR DESCRIPTION
To be able to run tests that rely on dependencies via :foreign-libs or :libs something like this is needed.  