### PR TITLE
[Fix #14] Use :default-fn for :dir command line option

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,6 @@
  :deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/clojurescript {:mvn/version "1.10.339"}
         org.clojure/tools.namespace {:mvn/version "0.3.0-alpha4"}
-        org.clojure/tools.cli {:mvn/version "0.3.7"}
+        org.clojure/tools.cli {:mvn/version "0.4.1"}
         doo {:mvn/version "0.1.10"}}
  :aliases {:test {:main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -155,9 +155,9 @@
 (def cli-options
   "Options for use with clojure.tools.cli."
   [["-d" "--dir DIRNAME" "The directory containing your test files"
-    :default #{"test"}
     :default-desc "test"
-    :assoc-fn accumulate]
+    :assoc-fn accumulate
+    :default-fn (constantly #{"test"})]
    ["-n" "--namespace SYMBOL" "Symbol indicating a specific namespace to test."
     :id :ns-symbols
     :parse-fn symbol


### PR DESCRIPTION
Because of the way `tools.cli` threads default values, the default dir was always
conjoined in the `:dir` key. This is not what we want, cause if the user
specifies the `--dir` option, she likely does not have "test" in her code base.

This patch uses the new `:default-fn` feature (present in `tools.cli` `0.4.1`) to set
the default value *after* the command line option parsing.