### PR TITLE
Filter tests under :advanced

### DIFF
--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -29,15 +29,12 @@
             (test-inclusion %)
             (test-exclusion %))))
 
-  (defn unmap [ns sym]
-    (js-delete ns (str (munge sym))))
-
   (defn filter-vars! [ns-syms filter-fn]
     (doseq [[ns syms] ns-syms]
       (doseq [[name var] syms]
         (when (:test (meta var))
           (when (not (filter-fn var))
-            (unmap ns name))))))
+            (set! (.-cljs$lang$test @var) nil))))))
   ")
 
 (defn format-value


### PR DESCRIPTION
Hey @Olical, it appears that filtering tests via on meta doesn't currently work under `:advanced`, and this PR makes a tweak that fixes this aspect. 

At its root is that under `:advanced` the symbol used for a given test will have been renamed, thus thwarting `unmap`'s ability to remove the test function by trying to name it in the call to `js-delete`. But, it suffices to just delete the test property from the function. That's where the `:test` meta is ultimately derived anyway. See https://github.com/clojure/clojurescript/blob/848e10a9dac539b9271d83577fc1266f18e949da/src/main/clojure/cljs/analyzer.cljc#L1471

So this PR instead just sets the `cljs$lang$test` property to `null`. Of course, this makes `cljs-test-runner` a bit tied to an internal implementation detail of the ClojureScript compiler. Perhaps some better way can be found, but, if I had to speculate, I this property is probably pretty stable at this point and extremely unlikely to change.

Having said all of this, if you decide that you'd like to accept this PR, there might be other simplifications that can be done in the surrounding code. (For example, `ns` and `name` / `sym` would no longer be needed.) I haven't tried making more aggressive changes along those lines. I figure you may have feelings on whether you even want to take a PR like this, and if you do, honestly, you are in a better position to see the big picture on whether other simplifications are possible.