### PR TITLE
Support planck

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ clj -m cljs-test-runner.main -c ./config/advanced-compilation.edn
 
 There is a known issue with `:simple` and `:whitespace`, I just haven't invested the time into working out what it is. For now, stick to `:none` or `:advanced`, the original issue for optimisation levels breaking things is [#16][].
 
+### Planck
+
+To use Planck, add `"cljs-test-runner-out/gen` to the `:paths` in your `deps.edn`:
+
+```edn
+:paths ["src" "test" "cljs-test-runner-out/gen"]
+```
+
+and set the environment:
+
+    -x planck
+
 ## Unlicenced
 
 Find the full [unlicense][] in the `UNLICENSE` file, but here's a snippet.

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -119,7 +119,8 @@
                                      :phantom {:target :browser
                                                :doo-env :phantom}
                                      :chrome-headless {:target :browser
-                                                       :doo-env :chrome-headless})]
+                                                       :doo-env :chrome-headless}
+                                     :planck {:doo-env :planck})]
       (io/make-parents src-path)
       (spit src-path test-runner-cljs)
       (try
@@ -132,11 +133,12 @@
                                 compile-opts)
               run-tests-fn #(doo/run-script doo-env build-opts doo-opts)
               watch-opts (assoc build-opts :watch-fn run-tests-fn)]
-
-          (if (seq watch)
-            (cljs/watch (apply cljs/inputs (into watch (cons gen-path dir))) watch-opts)
-            (do (cljs/build gen-path build-opts)
-                (->> (run-tests-fn) :exit (reset! exit-code)))))
+          (if (= env :planck)
+            (->> (run-tests-fn) :exit (reset! exit-code))
+            (if (seq watch)
+              (cljs/watch (apply cljs/inputs (into watch (cons gen-path dir))) watch-opts)
+              (do (cljs/build gen-path build-opts)
+                  (->> (run-tests-fn) :exit (reset! exit-code))))))
         (catch Exception e
           (println e))
         (finally


### PR DESCRIPTION
Tests can be run with `-x planck` if you have planck installed. This fixes #24.