### PR TITLE
Read inline EDN compiler opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Now when you run the following, your tests will be executed with advanced compil
 clj -m cljs-test-runner.main -c ./config/advanced-compilation.edn
 ```
 
+You can also directly inline the EDN using the `-c` flag:
+
+```bash
+clj -m cljs-test-runner.main -c '{:optimizations :advanced}'
+```
+
 There is a known issue with `:simple` and `:whitespace`, I just haven't invested the time into working out what it is. For now, stick to `:none` or `:advanced`, the original issue for optimisation levels breaking things is [#16][].
 
 ### Planck

--- a/src/cljs_test_runner/main.clj
+++ b/src/cljs_test_runner/main.clj
@@ -93,11 +93,18 @@
   (mapcat #(find/find-namespaces-in-dir (io/file %) find/cljs) dirs))
 
 (defn load-opts
-  "Read EDN from the given path if not nil, otherwise returns an empty map."
-  [path]
-  (if path
-    (edn/read-string (slurp path))
-    {}))
+  "Load compiler options from input. Supports either an inline EDN map or assumed
+  to be a file path. If input is nil, returns empty map"
+  [path-or-data]
+  (cond
+    (nil? path-or-data)
+    {}
+
+    (= (first (str/trim path-or-data)) \{)
+    (edn/read-string path-or-data)
+
+    :else
+    (edn/read-string (slurp path-or-data))))
 
 (defn test-cljs-namespaces-in-dir
   "Execute all ClojureScript tests in a directory."
@@ -186,7 +193,7 @@
     :parse-fn parse-kw]
    ["-w" "--watch DIRNAME" "Directory to watch for changes (alongside the test directory). May be repeated."
     :assoc-fn accumulate]
-   ["-c" "--compile-opts PATH" "EDN file containing opts to be passed to the ClojureScript compiler."
+   ["-c" "--compile-opts PATH" "EDN opts or EDN file containing opts to be passed to the ClojureScript compiler."
     :parse-fn load-opts]
    ["-D" "--doo-opts PATH" "EDN file containing opts to be passed to doo."
     :parse-fn load-opts]


### PR DESCRIPTION
Added ability for `load-opts` to read the `-c` flag as EDN to support common use-case of just needing to add `{:optimizations :advanced}` without needing to have an EDN file. Tested via following command.

The existing behavior of passing a file also works. The `-c` option looks to see if it the first non-whitespace character is `\{` and treats as EDN, otherwise falls back to file.

```bash
 clj -Adev -m cljs-test-runner.main -c '{:optimizations :advanced}'
```